### PR TITLE
Fix typo in chapter 1 where page author was prefixed with "by" twice.

### DIFF
--- a/_chapters/why-software-testing.md
+++ b/_chapters/why-software-testing.md
@@ -3,7 +3,7 @@ chapter-number: 1
 title: Why software testing?
 layout: chapter
 toc: true
-author: by Maurício Aniche
+author: Maurício Aniche
 ---
 
 ## Motivation


### PR DESCRIPTION
In chapter 1, titled "Why software testing?", the following author text can be found:
"by by Mauricio Aniche". Commit [3c9769](https://github.com/sttp-book/sttp-book.github.io/commit/3c97691e543eb350fe4dacd6e1af9701e930d617) changed the template (layout) to [prefix](https://github.com/sttp-book/sttp-book.github.io/commit/3c97691e543eb350fe4dacd6e1af9701e930d617#diff-80cf53776d9532a183c2ce90dd5dedacR19)
page authors with the word "by", instead of writing in separately per page.
It seems that removing the "by [author]" was forgotten for the first chapter.

This commit simply fixes the above by removing the "by" in the author name in
chapter 1.