### PR TITLE
Structural-based chapter before model-based testing

### DIFF
--- a/_chapters/model-based-testing.md
+++ b/_chapters/model-based-testing.md
@@ -1,5 +1,5 @@
 ---
-chapter-number: 6
+chapter-number: 7
 title: Model-Based Testing
 layout: chapter
 toc: true

--- a/_chapters/structural-based-testing.md
+++ b/_chapters/structural-based-testing.md
@@ -1,5 +1,5 @@
 ---
-chapter-number: 7
+chapter-number: 6
 title: Structural-Based Testing
 layout: chapter
 toc: true


### PR DESCRIPTION
This PR makes the structural-based testing chapter to come before the model-based testing chapter.

See issue #6 